### PR TITLE
fix division by 0 bug for no reviews

### DIFF
--- a/utils/computeRatingAverage.js
+++ b/utils/computeRatingAverage.js
@@ -2,6 +2,6 @@ export const computeAverageRating = ({ results }) => {
   return (
     results.reduce((a, b) => {
       return a.rating + b.rating;
-    }, 0) / results.length
+    }, 0) / results.length || 0
   );
 };


### PR DESCRIPTION
Bug fix ticket# 58. 
- add a default value of zero when calculating average of zero reviews.